### PR TITLE
Drop any information if json-parse-string failed.

### DIFF
--- a/websocket-bridge.el
+++ b/websocket-bridge.el
@@ -51,8 +51,9 @@
 
 (defun websocket-bridge-message-handler (_websocket frame)
   "Message handler for given FRAME."
-  (let* ((info (json-parse-string (websocket-frame-text frame)))
-         (info-type (gethash "type" info nil)))
+  (let* ((info (ignore-errors (json-parse-string (websocket-frame-text frame))))
+         (info-type (when (hash-table-p info)
+                      (gethash "type" info nil))))
     (pcase info-type
       ("client-app-name"
        (set


### PR DESCRIPTION
才启动的时候， 如果发送字符串（不是json) 就会导致 on-message 错误。